### PR TITLE
fix: close popover when overlay is clicked

### DIFF
--- a/shared/popover.py
+++ b/shared/popover.py
@@ -78,7 +78,7 @@ class PopoverManager:
             visible=False,
             all_visible=False,
         )
-        GtkLayerShell.set_keyboard_interactivity(window, True)
+        GtkLayerShell.set_keyboard_mode(window, GtkLayerShell.KeyboardMode.ON_DEMAND)
         window.set_keep_above(True)
         return window
 
@@ -169,7 +169,6 @@ class Popover(Widget):
         else:
             self._manager.activate_popover(self)
             self._content_window.show()
-            self._content_window.steal_input()
             self._visible = True
 
         self.emit("popover-opened")
@@ -229,7 +228,6 @@ class Popover(Widget):
         self._content_window.connect("key-press-event", self._on_key_press)
         self._manager.activate_popover(self)
         self._content_window.show()
-        self._content_window.steal_input()
         self._visible = True
 
     def _on_popover_focus_out(self, widget, event):


### PR DESCRIPTION
### Description

Popover windows (at least quick_settings, cliphist) do not close when I click outside of their popover window. To close them I have had to press ESC instead. This PR fixes this issue.

### Additional context

The overlay window has event handler (`_on_overlay_clicked`) which is supposed to close popover window, but it is not called. This seems to be caused by call to `set_keyboard_interactivity` which grabs exclusive keyboard focus, which seems to steal mouse events too. Thus no window outside of the popover window receive `mouse-press-event`.

I've gotten this to work by using `ON_DEMAND` keyboard mode instead of `EXCLUSIVE` mode. Now the overlay window receives the mouse button press event and closes the popover window. ESC also works, and keyboard focus is still in popover window.

Note that `set_keyboard_interactivity` forwards calls to `set_keyboard_mode` ([see here](https://github.com/wmww/gtk-layer-shell/blob/2a8ddaa09844ba78783c95d288300a1d8a93e429/src/api.c#L234)), setting exclusive mode when 2nd arguments is True.

The `steal_input` also forwards calls to `set_keyboard_interactivity` ([see here](https://github.com/Fabric-Development/fabric/blob/27037055701557e42220a99d562439b918136bd6/fabric/widgets/wayland.py#L262)) so they were not required as the the keyboard mode was already set at window creation time.