### PR TITLE
allow hidding the battery widget if none is present

### DIFF
--- a/utils/constants.py
+++ b/utils/constants.py
@@ -45,6 +45,7 @@ DEFAULT_CONFIG = {
         "battery": {
             "full_battery_level": 100,
             "hide_label_when_full": True,
+            "hide_when_missing": True,
             "label": True,
             "tooltip": True,
             "icon_size": 14,

--- a/utils/widget_settings.py
+++ b/utils/widget_settings.py
@@ -73,6 +73,7 @@ Battery = TypedDict(
         "tooltip": bool,
         "full_battery_level": int,
         "hide_label_when_full": bool,
+        "hide_when_missing": bool,
         "icon_size": int,
         "notifications": Dict,
     },

--- a/widgets/battery.py
+++ b/widgets/battery.py
@@ -48,6 +48,8 @@ class BatteryWidget(ButtonWidget):
         is_present = self.client.get_property("IsPresent") == 1
 
         if not is_present:
+            if self.config.get("hide_when_missing", True):
+                self.set_visible(False)
             self.set_tooltip_text("󰂎 No battery present")
             if self.config.get("label", True):
                 self.battery_label.set_text("N/A")


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/rubiin/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Allow to hide the battery widget itself if  no battery is detected.
Configurable but enabled by default

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
