### PR TITLE
fix: hyprsunset slider functionality

### DIFF
--- a/widgets/quick_settings/submenu/hyprsunset.py
+++ b/widgets/quick_settings/submenu/hyprsunset.py
@@ -93,12 +93,12 @@ class HyprSunsetToggle(QSChevronButton):
         # reusing the fabricator to call specified intervals
         reusable_fabricator.connect("changed", self.update_action_button)
 
+
     def on_action(self, *_):
         """Handle the action button click event."""
-        toggle_command(
-            "hyprsunset",
-            full_command="hyprsunset -t 2600",
-        )
+        # Get current slider value for dynamic command
+        current_temp = int(self.submenu.scale.get_value())
+        toggle_command("hyprsunset", f"hyprsunset -t {current_temp}")
         return True
 
     def update_action_button(self, *_):

--- a/widgets/quick_settings/submenu/hyprsunset.py
+++ b/widgets/quick_settings/submenu/hyprsunset.py
@@ -34,20 +34,22 @@ class HyprSunsetSubMenu(QuickSubMenu):
             **kwargs,
         )
 
+        # Connect the slider immediately
+        self.scale.connect("value-changed", self.on_scale_move)
         self.revealer.connect("notify::revealed", self.on_revealer_revealed)
 
     def on_revealer_revealed(self, *_):
         """Handle the revealer being revealed."""
         self.update_scale()
-        self.scale.connect("value-changed", self.on_scale_move)
         reusable_fabricator.connect("changed", self.update_scale)
         return True
 
     @cooldown(0.1)
-    def on_scale_move(self, _, __, moved_pos):
+    def on_scale_move(self, scale):
+        temperature = int(scale.get_value())
         exec_shell_command_async(
-            f"hyprctl hyprsunset temperature {int(moved_pos)}",
-            lambda *_: self.update_ui(int(moved_pos)),
+            f"hyprctl hyprsunset temperature {temperature}",
+            lambda *_: self.update_ui(temperature),
         )
         return True
 


### PR DESCRIPTION
# PR: Fix HyprSunset Slider Functionality

## Summary
Fixed the HyprSunset widget slider to properly respond to user input and control the blue light filter temperature in real-time.

## Problem
The HyprSunset slider widget was not responding to user interactions. The slider value was never being used to update the temperature, and the toggle button was using a hardcoded temperature value (2600K) instead of respecting the slider position.

## Solution

### 1. Fixed Signal Connection Timing
**Issue**: The slider signal was only connected when the submenu revealer was revealed (`notify::revealed` signal), but this signal appears to never fire properly.

**Fix**: Moved the slider connection to the `__init__` method to ensure it's always connected:
```python
# Connect the slider immediately
self.scale.connect("value-changed", self.on_scale_move)
```

**Note**: This approach may not be the most optimized since it connects the signal even when the submenu isn't visible, but it works reliably.

### 2. Updated Toggle Button to Use Slider Value
**Before**: 
```python
toggle_command("hyprsunset", "hyprsunset -t 2600")  # Hardcoded 2600K
```

**After**:
```python
current_temp = int(self.submenu.scale.get_value())
toggle_command("hyprsunset", f"hyprsunset -t {current_temp}")  # Dynamic temperature
```

### 3. Fixed Signal Handler Parameters
Updated the `on_scale_move` method to properly handle the `value-changed` signal parameters:
```python
def on_scale_move(self, scale):
    temperature = int(scale.get_value())
    # ... update temperature
```

## Technical Notes

### Known Issues
- The `on_revealer_revealed` method is never called, suggesting the `notify::revealed` signal may not be working as expected in the current QuickSubMenu implementation
- The current solution connects the slider signal immediately rather than waiting for the submenu to be revealed, which may not be optimal for performance

### Future Improvements
- Investigate why `notify::revealed` signal doesn't fire
- Consider implementing a more efficient signal connection strategy
- Potentially refactor the QuickSubMenu base class to handle signal connections more reliably

## Testing
✅ Slider now responds to user input  
✅ Temperature changes in real-time when moving slider  
✅ Toggle button uses current slider value instead of hardcoded temperature  
✅ Both slider and toggle button work together consistently  

## Files Changed
- `widgets/quick_settings/submenu/hyprsunset.py`

## Functionality
- **Slider**: Move to set desired temperature (1000K - 10000K)
- **Toggle Button**: Enable/disable HyprSunset using current slider temperature
- **Real-time Updates**: Temperature changes immediately when slider is moved (if HyprSunset is running)
