### PR TITLE
feat: Add collapsible group widget with popup menu

### DIFF
--- a/example/config.json
+++ b/example/config.json
@@ -341,7 +341,7 @@
 		], // this is the middle section of the panel
 		"right_section": [
 			"recorder",
-			"@group:1",
+			"@collapsible:0",
 			"@group:0",
 			"system_tray"
 		] // this is the right section of the panel
@@ -365,6 +365,23 @@
 			"spacing": 0,
 			"style_classes": [
 				"compact"
+			]
+		}
+	],
+	"collapsible_groups": [ // collapsible groups create popup menus with utility widgets, accessed as @collapsible:0, @collapsible:1, etc
+		{
+			"widgets": [
+				"cliphist",
+				"emoji_picker",
+				"ocr",
+				"screenshot",
+				"recorder"
+			],
+			"spacing": 4,
+			"icon": "󰒓", // icon for the collapsible group button
+			"tooltip": "Utility Tools", // tooltip for the collapsible group button
+			"style_classes": [
+				"utility-tools"
 			]
 		}
 	],

--- a/example/config.toml
+++ b/example/config.toml
@@ -74,7 +74,7 @@ icon = ""
 [layout]
 left_section = [ "workspaces", "window_title" ]
 middle_section = [ "date_time" ]
-right_section = [ "recorder", "@group:1", "@group:0", "system_tray" ]
+right_section = [ "recorder", "@collapsible:0", "@group:0", "system_tray" ]
 
 [[widget_groups]]
 widgets = [ "updates", "ocr", "battery" ]
@@ -85,6 +85,20 @@ style_classes = [ "compact" ]
 widgets = [ "quick_settings", "cpu" ]
 spacing = 0
 style_classes = [ "compact" ]
+
+# Collapsible groups create popup menus with utility widgets, accessed as @collapsible:0, @collapsible:1, etc
+[[collapsible_groups]]
+widgets = [
+    "cliphist",
+    "emoji_picker",
+    "ocr",
+    "screenshot",
+    "recorder"
+]
+spacing = 4
+icon = "󰒓"  # icon for the collapsible group button
+tooltip = "Utility Tools"  # tooltip for the collapsible group button
+style_classes = [ "utility-tools" ]
 
 [memory]
 icon = ""
@@ -250,3 +264,33 @@ ignored = [ -99 ]
 reverse_scroll = false
 empty_scroll = false
 icon_map = { }
+
+[cliphist]
+icon = ""
+label = false
+tooltip = true
+
+[emoji_picker]
+icon = ""
+label = false
+tooltip = true
+
+[screenshot]
+path = "Pictures/Screenshots"
+icon_size = 16
+tooltip = true
+label = false
+annotation = true
+capture_sound = true
+icon = "󰄀"
+
+[hyprpicker]
+icon = ""
+tooltip = true
+label = false
+show_icon = true
+
+[kanban]
+icon = "󱞁"
+label = false
+tooltip = true

--- a/modules/bar.py
+++ b/modules/bar.py
@@ -13,6 +13,7 @@ from widgets.brightness import BrightnessWidget
 from widgets.cava import CavaWidget
 from widgets.click_counter import ClickCounterWidget
 from widgets.cliphist import ClipHistoryWidget
+from widgets.collapsible_group import CollapsibleGroupWidget
 from widgets.datetime_menu import DateTimeWidget
 from widgets.emoji_picker import EmojiPickerWidget
 from widgets.hypridle import HyprIdleWidget
@@ -97,12 +98,14 @@ class StatusBar(Window, BaseWidget):
             "divider": DividerWidget,
             "quick_settings": QuickSettingsButtonWidget,
             "window_count": WindowCountWidget,
+            "collapsible_group": CollapsibleGroupWidget,
         }
 
         options = config["general"]
         bar_config = config["modules"]["bar"]
         layout = self.make_layout(config)
 
+        # Main bar content (back to original CenterBox layout)
         self.box = CenterBox(
             name="panel-inner",
             start_children=Box(
@@ -166,6 +169,30 @@ class StatusBar(Window, BaseWidget):
                             self.widgets_list,
                         )
                         layout[key].append(group)
+                elif widget_name.startswith("@collapsible:"):
+                    # Handle collapsible groups
+                    group_name = widget_name.replace("@collapsible:", "", 1)
+                    group_config = None
+
+                    if group_name.isdigit():
+                        idx = int(group_name)
+                        groups = config.get("collapsible_groups", [])
+                        if isinstance(groups, list) and 0 <= idx < len(groups):
+                            group_config = groups[idx]
+
+                    if group_config:
+                        collapsible_group = CollapsibleGroupWidget()
+
+                        # Configure the collapsible group
+                        collapsible_group.config.update(group_config)
+                        collapsible_group.widgets_config = group_config.get(
+                            "widgets", []
+                        )
+                        # Set widgets list for lazy initialization
+                        collapsible_group.set_widgets(self.widgets_list)
+
+                        # Add button to layout
+                        layout[key].append(collapsible_group)
                 else:
                     # Handle regular widgets
                     if widget_name in self.widgets_list:

--- a/styles/collapsible_group.scss
+++ b/styles/collapsible_group.scss
@@ -1,0 +1,63 @@
+@use "variable";
+@use "theme";
+
+.panel-collapsible-group {
+  background-color: theme.$background-dark;
+  border-radius: variable.$radius-large;
+  padding: 0.1em 0.9em;
+  margin: 2px 8px;
+  box-shadow: 0 0 0 variable.$border-width theme.$shadow-color;
+}
+
+.collapsible_group.active {
+  background: theme.$accent-blue;
+  color: theme.$text-main;
+}
+
+.collapsible_group:hover {
+  background: theme.$surface-highlight;
+}
+
+.panel-collapsible-group .panel-button {
+  margin: 4px;
+  min-height: 32px;
+  min-width: 32px;
+  padding: 0;
+  background: transparent;
+  border: none;
+  box-shadow: none;
+}
+
+.panel-collapsible-group .panel-button:hover {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.panel-collapsible-group .panel-button:active {
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.panel-collapsible-group .panel-module-group {
+  border: none;
+  background: transparent;
+  box-shadow: none;
+  margin: 0;
+  padding: 0;
+}
+
+.panel-collapsible-group .panel-font-icon {
+  font-size: 22px;
+}
+
+.panel-collapsible-group.compact .panel-button {
+  margin: 3px;
+  min-height: 28px;
+  min-width: 28px;
+  padding: 0;
+  background: transparent;
+  border: none;
+  box-shadow: none;
+}
+
+.panel-collapsible-group.compact .panel-font-icon {
+  font-size: 20px;
+}

--- a/styles/main.scss
+++ b/styles/main.scss
@@ -18,6 +18,7 @@
 @use "emoji.scss";
 @use "quicksettings.scss";
 @use "app_launcher.scss";
+@use "collapsible_group.scss";
 
 /* unset so we can style everything from the ground up. */
 

--- a/tsumiki.schema.json
+++ b/tsumiki.schema.json
@@ -96,6 +96,16 @@
 						"type": "string",
 						"pattern": "^@group:\\d+$",
 						"description": "Specifies a group of widgets to display."
+					},
+					{
+						"type": "string",
+						"pattern": "^@collapsible:\\d+$",
+						"description": "Specifies a collapsible group of widgets to display."
+					},
+					{
+						"type": "string",
+						"pattern": "^@collapsible:\\d+$",
+						"description": "Specifies a collapsible group of widgets to display."
 					}
 				]
 			}
@@ -432,6 +442,66 @@
 									"type": "string"
 								},
 								"description": "Style classes to apply to the group (e.g. 'bordered', 'compact')"
+							}
+						},
+						"required": ["widgets"]
+					}
+				},
+				"collapsible_groups": {
+					"type": "array",
+					"items": {
+						"type": "object",
+						"properties": {
+							"icon": {
+								"type": "string",
+								"description": "Icon for the collapsible group button"
+							},
+							"show_icon": {
+								"type": "boolean",
+								"default": true,
+								"description": "Whether to show the icon"
+							},
+							"show_label": {
+								"type": "boolean",
+								"default": false,
+								"description": "Whether to show the label"
+							},
+							"label": {
+								"type": "string",
+								"description": "Label text for the button"
+							},
+							"tooltip": {
+								"type": "string",
+								"description": "Tooltip text for the button"
+							},
+							"icon_size": {
+								"type": "integer",
+								"default": 16,
+								"description": "Size of the icon"
+							},
+							"widgets": {
+								"type": "array",
+								"items": {
+									"type": "string"
+								},
+								"description": "List of widget names to include in the collapsible group"
+							},
+							"group": {
+								"type": "object",
+								"properties": {
+									"spacing": {
+										"type": "integer",
+										"default": 4,
+										"description": "Spacing between widgets in the group"
+									},
+									"style_classes": {
+										"type": "array",
+										"items": {
+											"type": "string"
+										},
+										"description": "Style classes to apply to the group"
+									}
+								}
 							}
 						},
 						"required": ["widgets"]
@@ -1390,6 +1460,58 @@
 					"delayed_timeout": {
 						"type": "integer",
 						"description": "Timeout in milliseconds for delayed recording"
+					}
+				}
+			},
+			"collapsible_group": {
+				"type": "object",
+				"properties": {
+					"icon": {
+						"type": "string",
+						"description": "Icon for the collapsible group button"
+					},
+					"show_icon": {
+						"type": "boolean",
+						"description": "Whether to show the icon"
+					},
+					"show_label": {
+						"type": "boolean",
+						"description": "Whether to show the label"
+					},
+					"label": {
+						"type": "string",
+						"description": "Label text for the button"
+					},
+					"tooltip": {
+						"type": "string",
+						"description": "Tooltip text for the button"
+					},
+					"icon_size": {
+						"type": "integer",
+						"description": "Size of the icon"
+					},
+					"widgets": {
+						"type": "array",
+						"items": {
+							"type": "string"
+						},
+						"description": "List of widget names to include in the collapsible group"
+					},
+					"group": {
+						"type": "object",
+						"properties": {
+							"spacing": {
+								"type": "integer",
+								"description": "Spacing between widgets in the group"
+							},
+							"style_classes": {
+								"type": "array",
+								"items": {
+									"type": "string"
+								},
+								"description": "Style classes to apply to the group"
+							}
+						}
 					}
 				}
 			}

--- a/tsumiki.schema.json
+++ b/tsumiki.schema.json
@@ -101,11 +101,6 @@
 						"type": "string",
 						"pattern": "^@collapsible:\\d+$",
 						"description": "Specifies a collapsible group of widgets to display."
-					},
-					{
-						"type": "string",
-						"pattern": "^@collapsible:\\d+$",
-						"description": "Specifies a collapsible group of widgets to display."
 					}
 				]
 			}
@@ -486,22 +481,17 @@
 								},
 								"description": "List of widget names to include in the collapsible group"
 							},
-							"group": {
-								"type": "object",
-								"properties": {
-									"spacing": {
-										"type": "integer",
-										"default": 4,
-										"description": "Spacing between widgets in the group"
-									},
-									"style_classes": {
-										"type": "array",
-										"items": {
-											"type": "string"
-										},
-										"description": "Style classes to apply to the group"
-									}
-								}
+							"spacing": {
+								"type": "integer",
+								"default": 4,
+								"description": "Spacing between widgets in the group"
+							},
+							"style_classes": {
+								"type": "array",
+								"items": {
+									"type": "string"
+								},
+								"description": "Style classes to apply to the group"
 							}
 						},
 						"required": ["widgets"]
@@ -1460,58 +1450,6 @@
 					"delayed_timeout": {
 						"type": "integer",
 						"description": "Timeout in milliseconds for delayed recording"
-					}
-				}
-			},
-			"collapsible_group": {
-				"type": "object",
-				"properties": {
-					"icon": {
-						"type": "string",
-						"description": "Icon for the collapsible group button"
-					},
-					"show_icon": {
-						"type": "boolean",
-						"description": "Whether to show the icon"
-					},
-					"show_label": {
-						"type": "boolean",
-						"description": "Whether to show the label"
-					},
-					"label": {
-						"type": "string",
-						"description": "Label text for the button"
-					},
-					"tooltip": {
-						"type": "string",
-						"description": "Tooltip text for the button"
-					},
-					"icon_size": {
-						"type": "integer",
-						"description": "Size of the icon"
-					},
-					"widgets": {
-						"type": "array",
-						"items": {
-							"type": "string"
-						},
-						"description": "List of widget names to include in the collapsible group"
-					},
-					"group": {
-						"type": "object",
-						"properties": {
-							"spacing": {
-								"type": "integer",
-								"description": "Spacing between widgets in the group"
-							},
-							"style_classes": {
-								"type": "array",
-								"items": {
-									"type": "string"
-								},
-								"description": "Style classes to apply to the group"
-							}
-						}
 					}
 				}
 			}

--- a/utils/functions.py
+++ b/utils/functions.py
@@ -458,6 +458,39 @@ def validate_widgets(parsed_data, default_config):
                             f"Invalid widget '{group_widget}' found in "
                             f"widget group {idx}. Please check the widget name."
                         )
+            elif widget.startswith("@collapsible:"):
+                # Handle collapsible groups
+                group_idx = widget.replace("@collapsible:", "", 1)
+                if not group_idx.isdigit():
+                    raise ValueError(
+                        "Invalid collapsible group index "
+                        f"'{group_idx}' in section {section}. Must be a number."
+                    )
+                idx = int(group_idx)
+                groups = parsed_data.get("collapsible_groups", [])
+                if not isinstance(groups, list):
+                    raise ValueError(
+                        "collapsible_groups must be an array when using "
+                        "@collapsible references"
+                    )
+                if not (0 <= idx < len(groups)):
+                    raise ValueError(
+                        "Collapsible group index "
+                        f"{idx} is out of range. Available indices: 0-{len(groups) - 1}"
+                    )
+                # Validate widgets inside the collapsible group
+                group = groups[idx]
+                if not isinstance(group, dict) or "widgets" not in group:
+                    raise ValueError(
+                        f"Invalid collapsible group at index {idx}. "
+                        "Must be an object with 'widgets' array."
+                    )
+                for group_widget in group["widgets"]:
+                    if group_widget not in default_config["widgets"]:
+                        raise ValueError(
+                            f"Invalid widget '{group_widget}' found in "
+                            f"collapsible group {idx}. Please check the widget name."
+                        )
             elif widget not in default_config["widgets"]:
                 raise ValueError(
                     f"Invalid widget '{widget}' found in section {section}. "

--- a/widgets/collapsible_group.py
+++ b/widgets/collapsible_group.py
@@ -1,0 +1,125 @@
+from fabric.widgets.box import Box
+from fabric.widgets.label import Label
+
+from shared.popover import Popover
+from shared.widget_container import ButtonWidget
+from utils.widget_utils import nerd_font_icon
+
+
+class CollapsibleGroupWidget(ButtonWidget):
+    """A collapsible button group that shows a main toggle button in the bar.
+
+    When clicked, reveals a popup menu with grouped widgets underneath.
+    Uses lazy initialization for performance.
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(name="collapsible_group", **kwargs)
+
+        self.group_config = self.config.get("group", {})
+        self.widgets_config = self.config.get("widgets", [])
+        self.icon_name = self.config.get("icon", "󰍽")
+        self.show_icon = self.config.get("show_icon", True)
+        self.show_label = self.config.get("show_label", False)
+        self.label_text = self.config.get("label", "Tools")
+        self.tooltip_text = self.config.get("tooltip", "Toggle tool menu")
+
+        self.is_expanded = False
+        self.popup = None
+        self.widgets_list = None
+
+        self._setup_button_content()
+        self.connect("clicked", self._on_toggle_clicked)
+
+        if self.tooltip_text:
+            self.set_tooltip_text(self.tooltip_text)
+
+    def _setup_button_content(self):
+        """Set up the content of the main toggle button."""
+        if self.show_icon:
+            icon = nerd_font_icon(
+                icon=self.icon_name,
+                props={"style_classes": "panel-font-icon"},
+            )
+            self.box.add(icon)
+
+        if self.show_label:
+            label = Label(
+                label=self.label_text,
+                style_classes="panel-text"
+            )
+            self.box.add(label)
+
+    def _setup_popup(self):
+        """Set up the popup that contains the grouped widgets."""
+        self.widgets_box = Box(
+            orientation="h",
+            spacing=self.group_config.get("spacing", 4),
+            style_classes=[
+                "panel-collapsible-group",
+                *self.group_config.get("style_classes", [])
+            ]
+        )
+
+        self._populate_widgets()
+
+        self.popup = Popover(
+            content=self.widgets_box,
+            point_to=self
+        )
+
+    def _on_toggle_clicked(self, button):
+        """Handle the toggle button click."""
+        if self.popup is None:
+            self._setup_popup()
+
+        if self.is_expanded:
+            self.popup.hide_popover()
+            self.is_expanded = False
+            self.set_has_class("active", False)
+        else:
+            self.popup.open()
+            self.is_expanded = True
+            self.set_has_class("active", True)
+
+    def _populate_widgets(self):
+        """Populate the widgets box with configured widgets."""
+        if not self.widgets_list or not hasattr(self, 'widgets_box'):
+            return
+
+        for child in self.widgets_box.get_children():
+            self.widgets_box.remove(child)
+
+        for widget_name in self.widgets_config:
+            if widget_name in self.widgets_list:
+                widget_class = self.widgets_list[widget_name]
+                try:
+                    widget_instance = widget_class()
+                    self.widgets_box.add(widget_instance)
+                except Exception as e:
+                    print(f"Failed to create widget {widget_name}: {e}")
+                    continue
+
+    def set_widgets(self, widgets_list):
+        """Set the widgets to be displayed in the collapsible group.
+
+        Args:
+            widgets_list: Dictionary mapping widget names to widget classes
+        """
+        self.widgets_list = widgets_list
+
+    def collapse(self):
+        """Collapse the group programmatically."""
+        if self.popup and self.is_expanded:
+            self.popup.hide_popover()
+            self.is_expanded = False
+            self.set_has_class("active", False)
+
+    def expand(self):
+        """Expand the group programmatically."""
+        if not self.is_expanded:
+            if self.popup is None:
+                self._setup_popup()
+            self.popup.open()
+            self.is_expanded = True
+            self.set_has_class("active", True)


### PR DESCRIPTION
## 📋 Summary

This PR introduces a new **collapsible group widget** that creates popup menus with utility widgets, providing a clean and organized way to group related tools under a single button in the bar layout.

## ✨ Features

### 🎯 Core Functionality
- **Popup-based menu system** using GTK Popover for native integration
- **Horizontal layout under menu button** as requested
- **Lazy widget initialization** for optimal performance
- **@collapsible: syntax** support in bar layout configuration

### 🔧 Utility Widgets Included
- `cliphist` - Clipboard history management
- `emoji_picker` - Emoji selection tool
- `ocr` - Optical character recognition
- `screenshot` - Screen capture utility
- `recorder` - Screen recording tool

### 🎨 Styling & UI
- **Flat icon design** matching the existing theme variables
- **Professional SCSS styling** with GTK-compatible CSS properties
- **Customizable icons and tooltips** for each collapsible group
- **Theme-aware styling** using existing color variables

## 🛠️ Technical Implementation

### New Files
- `widgets/collapsible_group.py` - Main widget implementation
- `styles/collapsible_group.scss` - Styling for collapsible groups

### Modified Files
- `modules/bar.py` - Added @collapsible: syntax support in layout processing
- `styles/main.scss` - Imported new collapsible group styles
- `tsumiki.schema.json` - Added schema validation for collapsible_groups
- `utils/functions.py` - Updated validation to support @collapsible: pattern
- `example/config.json` - Added example configuration
- `example/config.toml` - Added example configuration

## 📸 Preview

<img width="308" height="93" alt="image" src="https://github.com/user-attachments/assets/3c35a977-cb6d-4809-be01-b01766a76953" />

## 🚀 Future Enhancements

- Support for vertical orientation in popup menus
- Multiple collapsible groups per layout section
- Custom animations for popup transitions
- Drag-and-drop reordering within popup menus



---

**Ready for review and testing!** 🎉
