### PR TITLE
fix: regression on collapsible_groups

### DIFF
--- a/example/config.json
+++ b/example/config.json
@@ -375,7 +375,7 @@
 		"right_section": [
 			"recorder",
 			"@custom_button:1",
-			"@group:1",
+			"@collapsible:0",
 			"@group:0",
 			"system_tray"
 		] // this is the right section of the panel

--- a/modules/bar.py
+++ b/modules/bar.py
@@ -164,6 +164,23 @@ class StatusBar(Window, BaseWidget):
                             self.widgets_list,
                         )
                         layout[key].append(group)
+                elif widget_name.startswith("@collapsible:"):
+                    # Handle collapsible groups
+                    group_config = self._get_group_config(
+                        widget_name, "collapsible_groups", config
+                    )
+                    if group_config:
+                        collapsible_group = CollapsibleGroupWidget()
+
+                        # Configure the collapsible group using the new method
+                        collapsible_group.update_config(group_config)
+                        collapsible_group.widgets_config = group_config.get(
+                            "widgets", []
+                        )
+                        # Set widgets list for lazy initialization
+                        collapsible_group.set_widgets(self.widgets_list)
+                        # Add button to layout
+                        layout[key].append(collapsible_group)
                 elif widget_name.startswith("@custom_button:"):
                     # Handle individual custom buttons
                     button_index_str = widget_name.replace("@custom_button:", "", 1)

--- a/tsumiki.schema.json
+++ b/tsumiki.schema.json
@@ -99,6 +99,11 @@
 					},
 					{
 						"type": "string",
+						"pattern": "^@collapsible:\\d+$",
+						"description": "Specifies a collapsible group of widgets to display."
+					},
+					{
+						"type": "string",
 						"pattern": "^@custom_button:\\d+$",
 						"description": "Specifies an individual custom button by index (e.g., @custom_button:0, @custom_button:1)."
 					}

--- a/utils/functions.py
+++ b/utils/functions.py
@@ -470,37 +470,13 @@ def validate_widgets(parsed_data, default_config):
     for section in layout:
         for widget in layout[section]:
             if widget.startswith("@group:"):
-                # Handle widget groups
-                group_idx = widget.replace("@group:", "", 1)
-                if not group_idx.isdigit():
-                    raise ValueError(
-                        "Invalid widget group index "
-                        f"'{group_idx}' in section {section}. Must be a number."
-                    )
-                idx = int(group_idx)
-                groups = parsed_data.get("widget_groups", [])
-                if not isinstance(groups, list):
-                    raise ValueError(
-                        "widget_groups must be an array when using @group references"
-                    )
-                if not (0 <= idx < len(groups)):
-                    raise ValueError(
-                        "Widget group index "
-                        f"{idx} is out of range. Available indices: 0-{len(groups) - 1}"
-                    )
-                # Validate widgets inside the group
-                group = groups[idx]
-                if not isinstance(group, dict) or "widgets" not in group:
-                    raise ValueError(
-                        f"Invalid widget group at index {idx}. "
-                        "Must be an object with 'widgets' array."
-                    )
-                for group_widget in group["widgets"]:
-                    if group_widget not in default_config["widgets"]:
-                        raise ValueError(
-                            f"Invalid widget '{group_widget}' found in "
-                            f"widget group {idx}. Please check the widget name."
-                        )
+                _validate_group_reference(
+                    widget, section, parsed_data, default_config, "group"
+                )
+            elif widget.startswith("@collapsible:"):
+                _validate_group_reference(
+                    widget, section, parsed_data, default_config, "collapsible"
+                )
             elif widget.startswith("@custom_button:"):
                 # Handle individual custom buttons
                 button_idx = widget.replace("@custom_button:", "", 1)


### PR DESCRIPTION
# Restore runtime support for `collapsible_groups` in panel layout

This pull request restores the runtime logic for handling `@collapsible:N` references in the panel layout, ensuring that collapsible groups defined in the config are properly instantiated and displayed. This addresses a regression introduced by [commit 7c7397d](https://github.com/rubiin/Tsumiki/pull/110/commits/7c7397d272339ecaf66e0463e1805c8c70fff8d8) during a merge from `master` into `collapsible-group-widget`, which inadvertently removed the necessary code.

**Summary of changes:**
- Re-implements support for `collapsible_groups` in the panel layout logic.
- Ensures `@collapsible:N` entries in the layout are recognized and rendered as collapsible groups.
- Resolves the regression caused by commit 7c7397d.

**Impact:**
- Users can once again use collapsible groups in their panel configuration as intended.
- No breaking changes to other group or widget handling.

**Closes:** Regression issue with collapsible groups in panel layout.
