### PR TITLE
fix: Simple fix for PowerProfileItem active class

### DIFF
--- a/widgets/quick_settings/submenu/power_profiles.py
+++ b/widgets/quick_settings/submenu/power_profiles.py
@@ -54,8 +54,11 @@ class PowerProfileItem(Button):
         self.set_active(active)
 
     def set_active(self, active: str):
-        self.box.set_has_class("active", self.key == active)
-
+        style_context = self.box.get_style_context()
+        if self.key == active:
+            style_context.add_class("active")
+        else:
+            style_context.remove_class("active")
 
 class PowerProfileSubMenu(QuickSubMenu):
     """A submenu to display power profile options."""


### PR DESCRIPTION
# Fix: Simple fix for PowerProfileItem active class

## Problem
The `PowerProfileItem` widget needs to toggle the `active` CSS class on its `Box` child. The original code expected a `set_has_class` method, which does not exist on the `Box` class from the `fabric` library, causing runtime errors such as:

```
    self.box.set_has_class("active", self.key == active)
    ^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'Box' object has no attribute 'set_has_class'
```

## Solution Chosen (Simple Fix)
I chose the simplest fix: directly using the GTK `style_context` API in `set_active`. This works and is idiomatic for GTK, but it spreads style logic throughout the codebase.

## Better Alternatives
- Create a `Box` subclass (or mixin) with a `set_has_class` method, so toggling style classes is unified and reusable.
- Add `set_has_class` directly to the base `Box` class in the `fabric` library (if possible).
- Use a utility function for toggling style classes.

**Note:** The current solution is pragmatic, but for maintainability and code clarity, a unified method like `set_has_class` on a `Box` subclass is preferable.
