### PR TITLE
Feat: Add Auto-Reload Configuration Feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ The name Tsumiki (pronounced as su-me-ki) comes from the Japanese word "tsumiki"
 - ⚙️ **Highly Configurable**
   Control the positioning, behavior, and appearance of every widget and element. Tailor the experience to fit your exact needs.
 
+- 🔄 **Auto-Reload**
+  Automatically restarts when configuration files are modified, making development and customization seamless.
+
 - ⚡ **Lightweight & Fast**
   Designed with performance in mind — minimal memory and CPU usage.
 

--- a/example/config.json
+++ b/example/config.json
@@ -499,6 +499,7 @@
 		"auto_hide": false,
 		"debug": false,
 		"monitor_styles": true,
-		"location": "top"
+		"location": "top",
+		"auto_reload": true
 	}
 }

--- a/example/config.toml
+++ b/example/config.toml
@@ -150,6 +150,7 @@ auto_hide = false
 debug = true
 location = "top"
 widget_style = "default"
+auto_reload = true
 
   [general.screen_corners]
   enabled = false

--- a/main.py
+++ b/main.py
@@ -88,6 +88,12 @@ def main():
 
     process_and_apply_css(app)
 
+    # Start config file watching if enabled
+    if general_options.get("auto_reload", True):
+        from utils.config_watcher import start_config_watching
+        start_config_watching()
+        logger.info(f"{Colors.INFO}[Main] Config auto-reload enabled")
+
     # Run the application
     app.run()
 

--- a/tsumiki.schema.json
+++ b/tsumiki.schema.json
@@ -444,6 +444,10 @@
 				"check_updates": {
 					"type": "boolean",
 					"description": "Determines whether to check for updates on startup."
+				},
+				"auto_reload": {
+					"type": "boolean",
+					"description": "Determines whether to automatically reload the application when configuration files change."
 				}
 			}
 		},

--- a/utils/config_watcher.py
+++ b/utils/config_watcher.py
@@ -1,0 +1,109 @@
+"""
+Simple configuration file watcher for auto-reloading Tsumiki when config files change.
+"""
+
+import os
+import subprocess
+from typing import List
+
+from fabric.utils import get_relative_path
+from gi.repository import Gio, GLib
+from loguru import logger
+
+from utils.colors import Colors
+
+
+class ConfigWatcher:
+    """Simple file watcher that monitors config files and restarts Tsumiki."""
+
+    def __init__(self):
+        self.monitors: List[Gio.FileMonitor] = []
+        self.restart_pending = False
+
+        # Files to monitor
+        config_files = [
+            get_relative_path("../config.json"),
+            get_relative_path("../config.toml"),
+            get_relative_path("../theme.json"),
+        ]
+
+        # Set up monitors for existing files
+        for config_file in config_files:
+            if os.path.exists(config_file):
+                self._monitor_file(config_file)
+
+    def _monitor_file(self, file_path: str):
+        """Monitor a single file for changes."""
+        try:
+            file_obj = Gio.File.new_for_path(file_path)
+            monitor = file_obj.monitor_file(Gio.FileMonitorFlags.NONE, None)
+            monitor.connect("changed", self._on_file_changed, file_path)
+            self.monitors.append(monitor)
+            logger.info(
+                f"{Colors.INFO}[ConfigWatcher] Monitoring {os.path.basename(file_path)}"
+            )
+        except Exception as e:
+            logger.error(
+                f"{Colors.ERROR}[ConfigWatcher] Failed to monitor {file_path}: {e}"
+            )
+
+    def _on_file_changed(self, monitor, file, other_file, event_type, file_path):
+        """Handle file change events."""
+        if (
+            event_type == Gio.FileMonitorEvent.CHANGES_DONE_HINT
+            and not self.restart_pending
+        ):
+            self.restart_pending = True
+            logger.info(
+                (
+                    f"{Colors.INFO}[ConfigWatcher] Config changed: "
+                    f"{os.path.basename(file_path)}"
+                )
+            )
+
+            # Delay restart slightly to handle multiple rapid changes
+            GLib.timeout_add(1500, self._restart_tsumiki)
+
+    def _restart_tsumiki(self):
+        """Restart Tsumiki using the init script."""
+        try:
+            init_script = get_relative_path("../init.sh")
+            logger.info(f"{Colors.INFO}[ConfigWatcher] Restarting Tsumiki...")
+
+            # Run restart in background to avoid blocking
+            subprocess.Popen(
+                [init_script, "-restart"],
+                cwd=os.path.dirname(init_script),
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                start_new_session=True,
+            )
+        except Exception as e:
+            logger.error(f"{Colors.ERROR}[ConfigWatcher] Failed to restart: {e}")
+
+        return False  # Don't repeat
+
+    def stop(self):
+        """Stop monitoring files."""
+        for monitor in self.monitors:
+            monitor.cancel()
+        self.monitors.clear()
+
+
+# Global watcher instance
+_watcher = None
+
+
+def start_config_watching():
+    """Start watching config files for changes."""
+    global _watcher
+    if _watcher is None:
+        _watcher = ConfigWatcher()
+
+
+def stop_config_watching():
+    """Stop watching config files."""
+    global _watcher
+    if _watcher:
+        _watcher.stop()
+        _watcher = None

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -413,6 +413,7 @@ DEFAULT_CONFIG = {
         "debug": True,
         "monitor_styles": True,
         "location": "top",
+        "auto_reload": True,
     },
 }
 


### PR DESCRIPTION
# Add Auto-Reload Configuration Feature

## Summary
This PR adds an auto-reload feature that automatically restarts Tsumiki when configuration files are modified, making development and customization much more convenient.

## Changes
- **New Feature**: Configuration file monitoring with automatic restart
- **Config Option**: Added `auto_reload` setting (enabled by default)
- **Monitored Files**: `config.json`, `config.toml`, and `theme.json`
- **Smart Restart**: 1.5-second delay to handle multiple rapid changes
- **Non-blocking**: Uses existing `init.sh -restart` mechanism with proper venv support

## Implementation Details
- Simple file watcher using GLib's `FileMonitor`
- Minimal code changes (~60 lines in new `utils/config_watcher.py`)
- Leverages existing restart infrastructure
- Configurable via `"auto_reload": true/false` in config

## Files Modified
- `utils/config_watcher.py` - New file watcher implementation
- `main.py` - Integration with config watcher (3 lines added)
- `utils/constants.py` - Added default config option
- `tsumiki.schema.json` - Added schema validation
- `example/config.json` & `example/config.toml` - Updated examples
- `README.md` - Added feature mention

## Usage
Auto-reload is enabled by default. To disable:
```json
{
  "general": {
    "auto_reload": false
  }
}
```

## Benefits
- 🔄 No more manual restarts during config editing
- ⚡ Fast development workflow
- 🛡️ Non-intrusive (can be disabled)
- 🎯 Reuses existing restart mechanism (stable)
