### PR TITLE
feat: Add multi-monitor support

### DIFF
--- a/example/config.json
+++ b/example/config.json
@@ -504,6 +504,7 @@
 		"check_updates": false,
 		"debug": false,
 		"monitor_styles": true,
-		"auto_reload": true
+		"auto_reload": true,
+		"multi_monitor": false
 	}
 }

--- a/main.py
+++ b/main.py
@@ -52,9 +52,7 @@ def main():
     app = Application(APPLICATION_NAME)
 
     # Create status bars
-    bars = StatusBar.create_bars(widget_config)
-    for bar in bars:
-        app.add_window(bar)
+    StatusBar.create_bars(app, widget_config)
 
     if module_options["notification"]["enabled"]:
         from modules.notification import NotificationPopup

--- a/main.py
+++ b/main.py
@@ -48,8 +48,13 @@ def main():
     helpers.copy_theme(theme_config["name"])
     helpers.check_executable_exists("sass")
 
-    # Initialize the application with the status bar
-    app = Application(APPLICATION_NAME, StatusBar(widget_config))
+    # Initialize the application
+    app = Application(APPLICATION_NAME)
+
+    # Create status bars
+    bars = StatusBar.create_bars(widget_config)
+    for bar in bars:
+        app.add_window(bar)
 
     if module_options["notification"]["enabled"]:
         from modules.notification import NotificationPopup

--- a/modules/bar.py
+++ b/modules/bar.py
@@ -164,3 +164,39 @@ class StatusBar(Window):
                     layout[key].append(widget)
 
         return layout
+
+    @staticmethod
+    def create_bars(config):
+        """Crée une ou plusieurs barres selon la config multi_monitor"""
+        if config["general"].get("multi_monitor", False):
+            # Multi-monitor
+            from loguru import logger
+
+            from utils.colors import Colors
+            from utils.monitors import HyprlandWithMonitors
+
+            monitor_util = HyprlandWithMonitors()
+            monitor_names = monitor_util.get_monitor_names()
+
+            if not monitor_names:
+                logger.warning(
+                    f"{Colors.WARNING}[StatusBar] No monitors detected, "
+                    "creating single bar"
+                )
+                return [StatusBar(config)]
+
+            bars = []
+            for monitor_name in monitor_names:
+                monitor_id = monitor_util.get_gdk_monitor_id_from_name(monitor_name)
+                if monitor_id is not None:
+                    bars.append(StatusBar(config, monitor=monitor_id))
+                else:
+                    logger.warning(
+                        f"{Colors.WARNING}[StatusBar] Could not get ID for monitor: "
+                        f"{monitor_name}"
+                    )
+
+            return bars if bars else [StatusBar(config)]
+        else:
+            # Single monitor
+            return [StatusBar(config)]

--- a/tsumiki.schema.json
+++ b/tsumiki.schema.json
@@ -2176,6 +2176,11 @@
 				"auto_reload": {
 					"type": "boolean",
 					"description": "Determines whether to automatically reload the application when configuration files change."
+				},
+				"multi_monitor": {
+					"type": "boolean",
+					"description": "Enables multi-monitor support. When true, creates a status bar on all available monitors.",
+					"default": false
 				}
 			}
 		}

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -7,6 +7,7 @@ HOME_DIR = GLib.get_home_dir()
 NOTIFICATION_WIDTH = 400
 NOTIFICATION_IMAGE_SIZE = 48
 HIGH_POLL_INTERVAL = 3600  # 1 hour in seconds
+MONITOR_HOTPLUG_DELAY_MS = 500  # Delay for monitor hotplug recreation
 
 # Network service constants
 NETWORK_RECENCY_THRESHOLD_SECONDS = 300  # 5 minutes for WiFi network freshness

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -414,6 +414,7 @@ DEFAULT_CONFIG = {
         "monitor_styles": True,
         "location": "top",
         "auto_reload": True,
+        "multi_monitor": False
     },
 }
 

--- a/utils/monitors.py
+++ b/utils/monitors.py
@@ -54,3 +54,12 @@ class HyprlandWithMonitors(Hyprland):
         except Exception as e:
             logger.error(f"[Monitors] Error getting current GDK monitor ID: {e}")
             return None
+
+    def get_monitor_names(self) -> list[str]:
+        """Get list of all connected monitor names."""
+        try:
+            monitors = json.loads(self.send_command("j/monitors").reply)
+            return [monitor["name"] for monitor in monitors]
+        except Exception as e:
+            logger.error(f"[Monitors] Error getting monitor names: {e}")
+            return []

--- a/widgets/stats.py
+++ b/widgets/stats.py
@@ -116,7 +116,7 @@ class CpuWidget(ButtonWidget):
                 return "N/A"
 
             # current temperature
-            temp = temp.pop()[1]
+            temp = temp[-1][1] if temp else 0
 
             temp = round(temp) if self.config.get("round", True) else temp
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/rubiin/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Adds multi-monitor support for the status bar with automatic hotplug detection.

**Configuration:**
```json
{
  "general": {
    "multi_monitor": true
  }
}
```

**Features:**
- Creates one status bar per connected monitor
- Automatic monitor hotplug/unplug detection via Hyprland events
- Falls back to single monitor if detection fails
- Uses 500ms delay for monitor changes to allow system stabilization

**Implementation:**
- `StatusBar.create_bars(app, config)` - unified bar creation method
- `MonitorWatcher` class for Hyprland event handling
- `HyprlandWithMonitors` utility for monitor detection and GDK ID mapping
- Monitor configuration stored in `utils/constants.py`

### Linked Issues
Related to #122

### Additional context

